### PR TITLE
Fix window preview regex to preserve session:window format

### DIFF
--- a/scripts/.preview
+++ b/scripts/.preview
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-[ "$1" != '[cancel]' ] && [ "$1" != '[current]' ] && echo $1 | sed 's/: .*$//' | xargs -I{} tmux capture-pane -ep -t {}:
+[ "$1" != '[cancel]' ] && [ "$1" != '[current]' ] && echo $1 | sed 's/: [^:]*$//' | xargs -I{} tmux capture-pane -ep -t {}


### PR DESCRIPTION
  The original regex 's/: .*$/' was removing everything after the first colon,
  leaving only the session name. This caused 'can't find window #' errors
  because tmux needs the full 'session:window' format.

  Changed to 's/: [^:]*$/' to remove only the last ': ...' part,
  preserving the session:window format required by tmux commands.